### PR TITLE
Fixes broken selection color on Mac OS

### DIFF
--- a/espresso-theme.el
+++ b/espresso-theme.el
@@ -17,7 +17,7 @@
 
 Port of the default theme for Espresso on Mac OS X.")
 
-(let ((selection-color (if (featurep 'ns) "ns_selection_color" "#C9D0D9"))
+(let ((selection-color (if (featurep 'ns) "ns_selection_bg_color" "#C9D0D9"))
       (highlight-color "#EEE00A")
       (secondary-color "#FBE9AD")
       (active-color "#EEEEEE")


### PR DESCRIPTION
Currently, the background color for selected text shows as black in Emacs 26.1 on Mac OS High Sierra (10.13.6), making it completely unusable.

The culprit of this misbehavior seems to be a change made on 2013-09-28 to `faces.el`, where `ns_selection_color` was removed and `ns_selection_bg_color` and `ns_selection_fg_color` were introduced (see the [change log](https://github.com/jwiegley/emacs-release/blob/master/lisp/ChangeLog)).

This change fixes this misbehavior.

Before:
<img width="717" alt="espresso-broken-mac-os" src="https://user-images.githubusercontent.com/442314/47467412-e2e03200-d7bb-11e8-8d51-85def6ac96f0.png">

After:
<img width="706" alt="espresso-fixed-mac-os" src="https://user-images.githubusercontent.com/442314/47467448-fe4b3d00-d7bb-11e8-9656-5860ff15c0ca.png">
